### PR TITLE
fix: custom regex

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -10,6 +10,7 @@ function inlinePostCSS(options = {}) {
     const styleRegex = options.styleRegex
         ? options.styleRegex
         : /(css\`((.|\n)*)\`)/g;
+    const hasCustomRegex = options.styleRegex ? true : false;
     return {
         name: 'inline-postcss',
         transform(code, id) {
@@ -36,7 +37,10 @@ function inlinePostCSS(options = {}) {
                     : require(path.join(configFolder, 'postcss.config.js'))({
                         env: process.env.NODE_ENV,
                     });
-                const css = code.match(styleRegex)[0].split('`')[1];
+                let css = code.match(styleRegex)[0];
+                if (options.escapeTemplateString || !hasCustomRegex) {
+                    css = css.split('`')[1];
+                }
                 const opts = {
                     from: options.from ? path.join(process.cwd(), options.from) : id,
                     to: options.to ? path.join(process.cwd(), options.to) : id,

--- a/index.ts
+++ b/index.ts
@@ -10,6 +10,7 @@ export default function inlinePostCSS(options: any = {}) {
   const styleRegex = options.styleRegex
     ? options.styleRegex
     : /(css\`((.|\n)*)\`)/g;
+  const hasCustomRegex = options.styleRegex ? true : false;
   return {
     name: 'inline-postcss',
     transform(code, id) {
@@ -37,7 +38,10 @@ export default function inlinePostCSS(options: any = {}) {
           : require(path.join(configFolder, 'postcss.config.js'))({
               env: process.env.NODE_ENV,
             });
-        const css = code.match(styleRegex)[0].split('`')[1];
+        let css = code.match(styleRegex)[0];
+        if (options.escapeTemplateString || !hasCustomRegex) {
+          css = css.split('`')[1];
+        }
         const opts = {
           from: options.from ? path.join(process.cwd(), options.from) : id,
           to: options.to ? path.join(process.cwd(), options.to) : id,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -16,6 +16,7 @@ async function write({ input, outDir, options }) {
     plugins: [
       inlinePostCSS({
         styleRegex: /css\`((.|\n)*)\`(;)/gm,
+        escapeTemplateString: true,
         plugins: [require('postcss-rgb-plz')],
       }),
     ],


### PR DESCRIPTION
This PR fixes #2 while keeping the current functionality that properly escapes template strings. This PR also adds a new option `escapeTemplateString` to the plugin in the case someone wants to use custom regex with template strings still.